### PR TITLE
feat: responsive mobile nav & fix footer year (#9)

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -561,6 +561,8 @@ main { flex: 1; padding-bottom: 4rem; }
 @media (max-width: 768px) {
   html { font-size: 16px; }
 
+  .container { padding: 0 1rem; }
+
   .nav-links {
     display: none;
     flex-direction: column;
@@ -577,13 +579,23 @@ main { flex: 1; padding-bottom: 4rem; }
   .nav-links.open { display: flex; }
   .nav-links li { width: 100%; }
   .nav-links a {
-    display: block;
+    display: flex;
+    align-items: center;
     padding: 0.75rem 1.5rem;
     font-size: 0.95rem;
+    min-height: 44px;
   }
 
   .site-nav { position: sticky; }
-  .nav-toggle { display: flex; align-items: center; }
+  .nav-toggle {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 44px;
+    min-width: 44px;
+  }
+
+  .btn { min-height: 44px; display: inline-flex; align-items: center; }
 
   .hero { padding: 2.5rem 0 2rem; }
   .hero-layout { flex-direction: column; align-items: center; text-align: center; }

--- a/bibliography.html
+++ b/bibliography.html
@@ -83,7 +83,7 @@
 
   <footer class="site-footer">
     <div class="container footer-inner">
-      <span>&copy; 2025 Oruç Kahriman</span>
+      <span>&copy; 2026 Oruç Kahriman</span>
       <ul class="footer-links">
         <li>
           <a class="email-link" data-u="oruc.kahriman" data-d="charite.de" aria-label="Email">

--- a/blog/index.html
+++ b/blog/index.html
@@ -53,7 +53,7 @@
 
   <footer class="site-footer">
     <div class="container footer-inner">
-      <span>&copy; 2025 Oruç Kahriman</span>
+      <span>&copy; 2026 Oruç Kahriman</span>
       <ul class="footer-links">
         <li>
           <a href="mailto:oruc.kahriman@charite.de" aria-label="Email">

--- a/cv.html
+++ b/cv.html
@@ -308,7 +308,7 @@
 
   <footer class="site-footer">
     <div class="container footer-inner">
-      <span>&copy; 2025 Oruç Kahriman</span>
+      <span>&copy; 2026 Oruç Kahriman</span>
       <ul class="footer-links">
         <li>
           <a class="email-link" data-u="oruc.kahriman" data-d="charite.de" aria-label="Email">

--- a/index.html
+++ b/index.html
@@ -90,7 +90,7 @@
 
   <footer class="site-footer">
     <div class="container footer-inner">
-      <span>&copy; 2025 Oruç Kahriman</span>
+      <span>&copy; 2026 Oruç Kahriman</span>
       <ul class="footer-links">
         <li>
           <a class="email-link" data-u="oruc.kahriman" data-d="charite.de" aria-label="Email">


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
- Mobile container padding reduced to `1rem` (per issue spec)
- Nav links, hamburger toggle, and buttons meet ≥44px tap target requirement
- Footer copyright year corrected from 2025 → 2026 on all pages (index, cv, bibliography, blog)

## Test plan
- [ ] DevTools mobile view (375px): no horizontal overflow on any page
- [ ] Hamburger opens and closes nav
- [ ] Nav links and buttons visually meet 44px height on mobile
- [ ] Footer shows © 2026 on all four pages

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)