### PR TITLE
feat: add projects showcase page (#19)

### DIFF
--- a/bibliography.html
+++ b/bibliography.html
@@ -38,6 +38,7 @@
       <ul class="nav-links">
         <li><a href="/">About</a></li>
         <li><a href="cv.html">CV</a></li>
+        <li><a href="projects.html">Projects</a></li>
         <li><a href="blog/">Blog</a></li>
         <li><a href="bibliography.html" class="active">Bibliography</a></li>
       </ul>

--- a/blog/index.html
+++ b/blog/index.html
@@ -38,6 +38,7 @@
       <ul class="nav-links">
         <li><a href="/">About</a></li>
         <li><a href="/cv.html">CV</a></li>
+        <li><a href="/projects.html">Projects</a></li>
         <li><a href="/blog/" class="active">Blog</a></li>
         <li><a href="/bibliography.html">Bibliography</a></li>
       </ul>

--- a/cv.html
+++ b/cv.html
@@ -38,6 +38,7 @@
       <ul class="nav-links">
         <li><a href="/">About</a></li>
         <li><a href="cv.html" class="active">CV</a></li>
+        <li><a href="projects.html">Projects</a></li>
         <li><a href="blog/">Blog</a></li>
         <li><a href="bibliography.html">Bibliography</a></li>
       </ul>

--- a/index.html
+++ b/index.html
@@ -38,6 +38,7 @@
       <ul class="nav-links">
         <li><a href="/"               class="active">About</a></li>
         <li><a href="cv.html">CV</a></li>
+        <li><a href="projects.html">Projects</a></li>
         <li><a href="blog/">Blog</a></li>
         <li><a href="bibliography.html">Bibliography</a></li>
       </ul>

--- a/projects.html
+++ b/projects.html
@@ -1,0 +1,190 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Projects — Oruç Kahriman</title>
+  <meta name="description" content="Software and research projects by Oruç Kahriman — medical AI, mobile health, agentic LLM frameworks, and product lifecycle tooling.">
+  <meta name="author" content="Oruç Kahriman">
+  <meta property="og:title"       content="Projects — Oruç Kahriman">
+  <meta property="og:description" content="Software and research projects by Oruç Kahriman.">
+  <meta property="og:type"        content="website">
+  <meta property="og:url"         content="https://kahriman.org/projects.html">
+  <meta property="og:image"       content="https://kahriman.org/images/portrait.jpeg">
+  <meta name="twitter:card"       content="summary">
+  <meta name="twitter:title"      content="Projects — Oruç Kahriman">
+  <meta name="twitter:description" content="Software and research projects by Oruç Kahriman.">
+  <meta name="twitter:image"      content="https://kahriman.org/images/portrait.jpeg">
+  <link rel="canonical"           href="https://kahriman.org/projects.html">
+  <link rel="icon" href="favicon.ico" sizes="any">
+  <link rel="icon" type="image/svg+xml" href="favicon.svg">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Lora:ital,wght@0,400;0,600;1,400&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="assets/css/main.css">
+</head>
+<body>
+
+  <nav class="site-nav" aria-label="Main navigation">
+    <div class="container nav-inner">
+      <a href="/" class="nav-brand">Oruç Kahriman</a>
+      <button class="nav-toggle" aria-label="Toggle navigation" aria-expanded="false">
+        <svg width="22" height="22" viewBox="0 0 22 22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+          <line x1="3" y1="6"  x2="19" y2="6"/>
+          <line x1="3" y1="11" x2="19" y2="11"/>
+          <line x1="3" y1="16" x2="19" y2="16"/>
+        </svg>
+      </button>
+      <ul class="nav-links">
+        <li><a href="/">About</a></li>
+        <li><a href="cv.html">CV</a></li>
+        <li><a href="projects.html" class="active">Projects</a></li>
+        <li><a href="blog/">Blog</a></li>
+        <li><a href="bibliography.html">Bibliography</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <main>
+    <div class="container">
+
+      <div class="page-header">
+        <h1>Projects</h1>
+        <p class="subtitle">Selected research and software projects.</p>
+      </div>
+
+      <!-- Malik -->
+      <article style="margin-bottom: 3.5rem;">
+        <h2>Malik</h2>
+        <div class="tags" style="margin-bottom: 1rem;">
+          <span class="tag">Flutter</span>
+          <span class="tag">Dart</span>
+          <span class="tag">Firebase</span>
+          <span class="tag">Polar H10</span>
+          <span class="tag">MDR Class IIa</span>
+          <span class="tag">ECG</span>
+        </div>
+        <p>
+          A mobile ECG acquisition and analysis app built in Flutter. The app pairs with a Polar H10
+          chest strap over Bluetooth to record 5-minute ECG sessions, uploads raw signals to a Google
+          Firebase backend, and runs a signal processing pipeline covering noise reduction, beat
+          detection, and HRV &amp; cardiac parameter calculation. The project also documents the MDR
+          regulatory classification and compliance path for a Class IIa medical device under the EU
+          Medical Device Regulation.
+        </p>
+        <figure>
+          <img src="images/architecture.png"
+               alt="Malik app system architecture diagram showing data flow from Polar H10 through BLE to Flutter app and Firebase backend">
+          <figcaption>System architecture: Polar H10 → BLE → Flutter app → Firebase backend → signal processing pipeline.</figcaption>
+        </figure>
+        <figure>
+          <img src="images/screenshot-measurement-mock.png"
+               alt="Malik app measurement screen showing a live ECG waveform during a recording session">
+          <figcaption>Measurement screen: live ECG trace streamed from the Polar H10 chest strap.</figcaption>
+        </figure>
+        <figure>
+          <img src="images/screenshot-results-mock.png"
+               alt="Malik app results screen showing calculated HRV metrics and cardiac parameters">
+          <figcaption>Results screen: HRV and cardiac parameters computed after session upload.</figcaption>
+        </figure>
+      </article>
+
+      <hr>
+
+      <!-- TRANSFER -->
+      <article style="margin-bottom: 3.5rem; margin-top: 2.5rem;">
+        <h2>TRANSFER</h2>
+        <div class="tags" style="margin-bottom: 1rem;">
+          <span class="tag">Kafka</span>
+          <span class="tag">TimeScaleDB</span>
+          <span class="tag">FHIR</span>
+          <span class="tag">Triton</span>
+          <span class="tag">Docker</span>
+          <span class="tag">Deep Learning</span>
+          <span class="tag">Hypotension Prediction</span>
+        </div>
+        <p>
+          An end-to-end ML system for near-real-time intraoperative hypotension prediction built at
+          ID&nbsp;Information und Dokumentation Berlin GmbH as part of a doctoral research project
+          at Charité Universitätsmedizin Berlin. OR time-series streams are ingested via Kafka and
+          persisted to both TimeScaleDB and a FHIR store. A preprocessing and inference pipeline runs
+          through a Triton Model Server, with all components deployed as Docker containers.
+        </p>
+        <p>
+          <a href="https://www.transfer-project.healthcare/de" target="_blank" rel="noopener" class="btn btn-secondary" style="display: inline-flex; align-items: center; gap: 0.4rem;">
+            Project website
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
+          </a>
+        </p>
+      </article>
+
+      <hr>
+
+      <!-- Mirash -->
+      <article style="margin-bottom: 3.5rem; margin-top: 2.5rem;">
+        <h2>Mirash</h2>
+        <div class="tags" style="margin-bottom: 1rem;">
+          <span class="tag">Python</span>
+          <span class="tag">LLM</span>
+          <span class="tag">Multi-agent</span>
+          <span class="tag">Agentic AI</span>
+        </div>
+        <p>
+          An agentic LLM framework that closes the development loop between project manager, developer,
+          and tester roles. Mirash coordinates multiple LLM agents to automate iterative software
+          development tasks — planning, implementation, review, and testing — reducing the manual
+          overhead of the inner dev loop.
+        </p>
+      </article>
+
+      <hr>
+
+      <!-- llemon -->
+      <article style="margin-bottom: 3.5rem; margin-top: 2.5rem;">
+        <h2>llemon</h2>
+        <div class="tags" style="margin-bottom: 1rem;">
+          <span class="tag">Python</span>
+          <span class="tag">LLM</span>
+          <span class="tag">Product Lifecycle</span>
+          <span class="tag">SKU Management</span>
+        </div>
+        <p>
+          A SKU product lifecycle management tool that automates the full lifecycle of product stock
+          units — from creation through end-of-life — using structured LLM-assisted workflows.
+          Designed to reduce manual data entry and classification effort in inventory and procurement
+          contexts.
+        </p>
+      </article>
+
+    </div>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer-inner">
+      <span>&copy; 2026 Oruç Kahriman</span>
+      <ul class="footer-links">
+        <li>
+          <a class="email-link" data-u="oruc.kahriman" data-d="charite.de" aria-label="Email">
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="4" width="20" height="16" rx="2"/><path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7"/></svg>
+            <span class="email-text"></span>
+          </a>
+        </li>
+        <li>
+          <a href="https://github.com/Oruc93" target="_blank" rel="noopener" aria-label="GitHub">
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0 1 12 6.844a9.59 9.59 0 0 1 2.504.337c1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.02 10.02 0 0 0 22 12.017C22 6.484 17.522 2 12 2z"/></svg>
+            GitHub
+          </a>
+        </li>
+        <li>
+          <a href="https://www.linkedin.com/in/oruc-kahriman-931b56122/" target="_blank" rel="noopener" aria-label="LinkedIn">
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor"><path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 0 1-2.063-2.065 2.064 2.064 0 1 1 2.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/></svg>
+            LinkedIn
+          </a>
+        </li>
+      </ul>
+    </div>
+  </footer>
+
+  <script src="assets/js/main.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- New `projects.html` with 4 project sections: Malik (3 images), TRANSFER (link to project site), Mirash, llemon
- Projects nav link added to all 5 pages (relative on root pages, absolute on `blog/index.html`)
- Reuses only existing CSS classes — no new styles

## Test plan
- [ ] All 4 projects render with tags and descriptions
- [ ] Malik shows architecture, measurement, and results images with captions
- [ ] TRANSFER "Project website" button opens https://www.transfer-project.healthcare/de in new tab
- [ ] "Projects" nav link appears on all pages and is active on `projects.html`
- [ ] Mobile hamburger nav works on `projects.html`

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)