### PR TITLE
feat: BibTeX download for publications (#21)

### DIFF
--- a/assets/kahriman.bib
+++ b/assets/kahriman.bib
@@ -1,0 +1,35 @@
+@article{Kranz2025latent,
+  author    = {Kranz, Dennis D. and Kr{\"a}mer, Jan F. and Kahriman, Oru{\c{c}} and Nelde, Annika and others},
+  title     = {Exploring Latent Diffusion Models for {ECG} Generation on the Minute Scale},
+  journal   = {Computer Methods and Programs in Biomedicine},
+  year      = {2025},
+  publisher = {Elsevier},
+  url       = {https://www.sciencedirect.com/science/article/pii/S0169260725005541}
+}
+
+@article{Kranz2025magnetocardiography,
+  author    = {Kranz, Dennis D. and Kahriman, Oru{\c{c}} and Dischl, D. and Treskatsch, S. and others},
+  title     = {Deep learning enhanced magnetocardiography enables multi-task detection of coronary, ventricular, and rhythm disorders},
+  journal   = {medRxiv},
+  year      = {2025},
+  note      = {Preprint},
+  url       = {https://www.medrxiv.org/content/medrxiv/early/2025/12/02/2025.11.30.25341301.full.pdf}
+}
+
+@inproceedings{Kranz2024diffusion,
+  author    = {Kranz, D. and Kahriman, Oru{\c{c}} and Wessel, N. and Kraemer, J.},
+  title     = {Can Diffusion Models Understand the Long Term Dependencies in an {ECG}?},
+  booktitle = {Workshop on Biosignals (WSBiosignals 2024)},
+  year      = {2024},
+  publisher = {G{\"o}ttingen Research Online},
+  url       = {https://publications.goettingen-research-online.de/bitstream/2/142313/1/WSBiosignals2024_Kranz.pdf}
+}
+
+@inproceedings{Kahriman2024transformer,
+  author    = {Kahriman, Oru{\c{c}} and Kranz, D. and Wessel, N. and Kr{\"a}mer, J.},
+  title     = {Optimizing Transformer Architecture for Time Series Analysis in Cardiovascular Signal Processing},
+  booktitle = {Workshop on Biosignals (WSBiosignals 2024)},
+  year      = {2024},
+  publisher = {G{\"o}ttingen Research Online},
+  url       = {https://publications.goettingen-research-online.de/bitstream/2/142216/1/WSBiosignals2024_Kahriman.pdf}
+}

--- a/bibliography.html
+++ b/bibliography.html
@@ -52,6 +52,10 @@
         <p class="subtitle">Standards, regulations, and references cited across blog posts — and own publications as they appear.</p>
       </div>
 
+      <div class="btn-group" style="margin-bottom: 2rem;">
+        <a href="assets/kahriman.bib" download class="btn btn-secondary">Download .bib ↓</a>
+      </div>
+
       <!-- Own publications -->
       <section class="bib-section">
         <h2>Own publications</h2>


### PR DESCRIPTION
## Summary
- `assets/kahriman.bib` with all 4 publications in valid BibTeX format (LaTeX-escaped special chars: `Oru{\c{c}}`, `Kr{\"a}mer`, `G{\"o}ttingen`)
- "Download .bib ↓" button added to `bibliography.html` below the page header

## Test plan
- [ ] Clicking "Download .bib ↓" downloads the file (not navigates to it)
- [ ] All 4 entries present: 2 articles, 2 inproceedings
- [ ] Special characters correct when opened in JabRef or similar

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)