### PR TITLE
feat: SEO — sitemap.xml, robots.txt, JSON-LD Person schema

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,24 @@
   <meta name="twitter:title"      content="Oruç Kahriman">
   <meta name="twitter:description" content="Medical AI researcher and data scientist based in Berlin. PhD candidate at Charité.">
   <meta name="twitter:image"      content="https://kahriman.org/images/portrait.jpeg">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Person",
+    "name": "Oruç Kahriman",
+    "url": "https://kahriman.org/",
+    "image": "https://kahriman.org/images/portrait.jpeg",
+    "jobTitle": "Medical AI Researcher & Data Scientist",
+    "worksFor": {
+      "@type": "Organization",
+      "name": "Charité Universitätsmedizin Berlin"
+    },
+    "sameAs": [
+      "https://github.com/Oruc93",
+      "https://www.linkedin.com/in/oruc-kahriman-931b56122/"
+    ]
+  }
+  </script>
   <link rel="canonical"           href="https://kahriman.org/">
   <link rel="icon" href="favicon.ico" sizes="any">
   <link rel="icon" type="image/svg+xml" href="favicon.svg">

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://kahriman.org/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://kahriman.org/</loc><changefreq>monthly</changefreq><priority>1.0</priority></url>
+  <url><loc>https://kahriman.org/cv.html</loc><changefreq>monthly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://kahriman.org/projects.html</loc><changefreq>monthly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://kahriman.org/blog/</loc><changefreq>weekly</changefreq><priority>0.7</priority></url>
+  <url><loc>https://kahriman.org/bibliography.html</loc><changefreq>monthly</changefreq><priority>0.6</priority></url>
+</urlset>


### PR DESCRIPTION
Closes #22\n\n## Summary\n- Add `sitemap.xml` with all 5 pages (index, cv, projects, blog, bibliography), no `<lastmod>` to avoid stale dates\n- Add `robots.txt` referencing the sitemap\n- Add JSON-LD `Person` schema to `index.html` with name, URL, image, jobTitle, worksFor, and sameAs (GitHub + LinkedIn)\n\n## Test plan\n- [ ] `https://kahriman.org/sitemap.xml` serves valid XML with 5 URLs\n- [ ] `https://kahriman.org/robots.txt` accessible and references sitemap\n- [ ] JSON-LD validates at https://validator.schema.org\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)"