### PR TITLE
feat(blog): blog index and first post — Malik MDR walkthrough

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -529,6 +529,17 @@ main { flex: 1; padding-bottom: 4rem; }
 .post-body ol { margin-bottom: 1.25rem; }
 .post-body li { margin-bottom: 0.25rem; }
 
+/* ── Author note (post footer aside) ───────────────────────── */
+.post-author-note {
+  margin-top: 3rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--border);
+  font-size: 0.9375rem;
+  color: var(--text-muted);
+  line-height: 1.7;
+  font-family: var(--font-sans);
+}
+
 /* ── Bibliography ───────────────────────────────────────────── */
 .bib-section { margin-bottom: 3rem; }
 .bib-section h2 {

--- a/blog/index.html
+++ b/blog/index.html
@@ -53,7 +53,25 @@
         <p class="subtitle">Notes on medical AI, biosignal analysis, and software regulation.</p>
       </div>
 
-      <p class="subtitle">Posts coming soon.</p>
+      <ul class="post-list">
+        <li class="post-card">
+          <div class="post-card-title">
+            <a href="malik-regulatory.html">A Developer&#8217;s Regulatory Walkthrough of a Real Medical App</a>
+          </div>
+          <div class="post-card-meta">
+            <time datetime="2026-04">April 2026</time>
+            <span class="tags">
+              <span class="tag">medical-device</span>
+              <span class="tag">MDR</span>
+              <span class="tag">flutter</span>
+              <span class="tag">firebase</span>
+              <span class="tag">privacy</span>
+            </span>
+          </div>
+          <p class="post-card-excerpt">I built a cardiac monitoring app. Then I started working in medical device software professionally and spent weeks going back through my own codebase asking what it would actually take to bring it to market legally.</p>
+          <a href="malik-regulatory.html" class="read-more">Read more &rarr;</a>
+        </li>
+      </ul>
 
     </div>
   </main>

--- a/blog/malik-regulatory.html
+++ b/blog/malik-regulatory.html
@@ -1,0 +1,329 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>A Developer&#8217;s Regulatory Walkthrough of a Real Medical App — Oruç Kahriman</title>
+  <meta name="description" content="I built a cardiac monitoring app. Then I started working in medical device software professionally and spent weeks going back through my own codebase asking what it would actually take to bring it to market legally.">
+  <meta name="author" content="Oruç Kahriman">
+  <meta property="og:title"       content="A Developer&#8217;s Regulatory Walkthrough of a Real Medical App">
+  <meta property="og:description" content="I built a cardiac monitoring app. Then I started working in medical device software professionally and spent weeks going back through my own codebase asking what it would actually take to bring it to market legally.">
+  <meta property="og:type"        content="article">
+  <meta property="og:url"         content="https://kahriman.org/blog/malik-regulatory.html">
+  <meta property="og:image"       content="https://kahriman.org/images/architecture.png">
+  <meta name="twitter:card"       content="summary_large_image">
+  <meta name="twitter:title"      content="A Developer&#8217;s Regulatory Walkthrough of a Real Medical App">
+  <meta name="twitter:description" content="I built a cardiac monitoring app. Then I started working in medical device software professionally and spent weeks going back through my own codebase asking what it would actually take to bring it to market legally.">
+  <meta name="twitter:image"      content="https://kahriman.org/images/architecture.png">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    "headline": "A Developer's Regulatory Walkthrough of a Real Medical App",
+    "author": {
+      "@type": "Person",
+      "name": "Oruç Kahriman",
+      "url": "https://kahriman.org/"
+    },
+    "datePublished": "2026-04",
+    "url": "https://kahriman.org/blog/malik-regulatory.html",
+    "image": "https://kahriman.org/images/architecture.png",
+    "description": "I built a cardiac monitoring app. Then I started working in medical device software professionally and spent weeks going back through my own codebase asking what it would actually take to bring it to market legally."
+  }
+  </script>
+  <link rel="canonical"           href="https://kahriman.org/blog/malik-regulatory.html">
+  <link rel="icon" href="../favicon.ico" sizes="any">
+  <link rel="icon" type="image/svg+xml" href="../favicon.svg">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Lora:ital,wght@0,400;0,600;1,400&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../assets/css/main.css">
+</head>
+<body>
+
+  <nav class="site-nav" aria-label="Main navigation">
+    <div class="container nav-inner">
+      <a href="/" class="nav-brand">Oruç Kahriman</a>
+      <button class="nav-toggle" aria-label="Toggle navigation" aria-expanded="false">
+        <svg width="22" height="22" viewBox="0 0 22 22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+          <line x1="3" y1="6"  x2="19" y2="6"/>
+          <line x1="3" y1="11" x2="19" y2="11"/>
+          <line x1="3" y1="16" x2="19" y2="16"/>
+        </svg>
+      </button>
+      <ul class="nav-links">
+        <li><a href="/">About</a></li>
+        <li><a href="/cv.html">CV</a></li>
+        <li><a href="/projects.html">Projects</a></li>
+        <li><a href="/blog/" class="active">Blog</a></li>
+        <li><a href="/bibliography.html">Bibliography</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <main>
+    <div class="container">
+
+      <header class="post-header">
+        <h1>A Developer&#8217;s Regulatory Walkthrough of a Real Medical App</h1>
+        <div class="post-meta">
+          <time datetime="2026-04">April 2026</time>
+          <span class="tags">
+            <span class="tag">medical-device</span>
+            <span class="tag">MDR</span>
+            <span class="tag">flutter</span>
+            <span class="tag">firebase</span>
+            <span class="tag">privacy</span>
+          </span>
+        </div>
+      </header>
+
+      <article class="post-body">
+
+        <p>I built a cardiac monitoring app. A Polar H10 chest strap streams ECG data over Bluetooth, a cloud backend processes the signal, and a physician sees the results on a mobile screen. It works. I was proud of it.</p>
+
+        <p>Then I started working in medical device software professionally. I spent the next few weeks going back through my own codebase and asking what it would actually take to bring something like this to market legally. I work at the intersection of signal processing and medical device software, and the answer turned out to be more structured and more interesting than I expected. Every layer of the architecture raises a different regulatory question. This post walks through each one.</p>
+
+        <figure>
+          <img src="../images/architecture.png" alt="Malik System Architecture" width="600">
+          <figcaption>Malik system architecture. The dashed line marks the SaMD (Software as a Medical Device) boundary - everything inside is subject to MDR evaluation. Firebase sits outside the boundary but carries GDPR obligations for health data.</figcaption>
+        </figure>
+
+        <figure>
+          <img src="../images/screenshot-measurement-mock.png" alt="Malik app measurement screen" width="300">
+          <figcaption>Malik during a live measurement session. The Polar H10 streams ECG data via Bluetooth. The app displays real-time heart rate (73 BPM), min/avg/max statistics, and a raw ECG waveform - all from a consumer-grade chest strap sensor.</figcaption>
+        </figure>
+
+        <hr>
+
+        <p>Before I get into the architecture, let me address the question I would have asked reading a post like this: why does any of this apply to me?</p>
+
+        <p>You do not choose whether your software is a medical device. The intended use does. The moment your software makes a claim directed at a clinical decision, detecting a condition, supporting a diagnosis, informing treatment, it enters medical device territory under the EU <a href="https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32017R0745">Medical Device Regulation (MDR)</a> regardless of what you call it or how you distribute it. A fitness app that shows heart rate is not a medical device. An app that displays cardiac parameters to a physician assessing heart health probably is. The code can be identical. The claim is what changes the classification.</p>
+
+        <p>Ignorance is not a defense. Understanding where the regulatory boundary sits is what lets you make a deliberate choice about which side of it you want to be on.</p>
+
+        <h2>The Architecture</h2>
+
+        <p>The architecture diagram above shows how the pieces connect, but it helps to walk through the user journey once before getting into the regulatory analysis. The measurement starts with the patient wearing the Polar H10 chest strap. The Malik app on the physician&#8217;s smartphone connects to the sensor over Bluetooth and runs a 5-minute ECG recording session. During that time the app collects raw ECG data locally and displays a live waveform so the physician can verify signal quality. When the session ends, the physician initiates the upload. The measurement is sent to Google Firebase, where a cloud function triggers automatically and runs the signal processing pipeline: noise reduction, beat detection, and calculation of cardiovascular parameters. The results are written back to the database and the app displays them to the physician in the same session.</p>
+
+        <p>That is the full loop. One sensor, one app, one cloud backend, one user.</p>
+
+        <h2>Is the Polar H10 a medical device?</h2>
+
+        <p>No, it is not and does not need to be.</p>
+
+        <p>The H10 is regarded as a gold standard for heart rate measurement in the consumer grade fitness industry. It records clinical-grade ECG measurements but Polar markets it for wellness and fitness purposes. It is <a href="https://single-market-economy.ec.europa.eu/single-market/ce-marking_en">CE-marked</a> as a consumer device but has no MDR certification, because Polar does not intend it for medical use.</p>
+
+        <p>When a developer pairs this consumer sensor with software that has a medical purpose, the regulatory picture is more subtle than &#8220;the software becomes the medical device.&#8221; What gets placed on the market is a <em>system</em>: app plus sensor, evaluated together. The MDR classification attaches to that combination, and the proof of safety and performance covers the whole chain. In practice that means I am also responsible for demonstrating that the H10&#8217;s measurements are reliable enough for the intended clinical use, and that validation becomes part of the technical file.</p>
+
+        <p>This is not hypothetical. The Czech telemedicine startup Kardi Ai achieved MDR IIa certification for their arrhythmia detection system using the Polar H10 as the sensor component. Polar states explicitly that the certification applies only to the Kardi Ai app <em>in combination with</em> the H10. The sensor on its own remains a consumer device. The certified object is the system.</p>
+
+        <hr>
+
+        <h2>Is the software a medical device?</h2>
+
+        <p>In the architecture diagram, everything inside the dashed SaMD (Software as a Medical Device) boundary, the Malik app and the signal processing backend, is the software under regulatory evaluation.</p>
+
+        <p>Whether software qualifies as a medical device depends entirely on what you claim it does. The framework for this determination is laid out in <a href="https://health.ec.europa.eu/document/download/b45335c5-1679-4c71-a91c-fc7a4d37f12b_en">MDCG 2019-11</a>, most recently revised in <a href="https://health.ec.europa.eu/latest-updates/update-mdcg-2019-11-rev1-qualification-and-classification-software-regulation-eu-2017745-and-2025-06-17_en">June 2025</a>.</p>
+
+        <p>This was the part that surprised me most. I could run the exact same noise reduction, beat detection and parameter calculation algorithms and market them as a fitness feature with no clinical claim. In that case, Malik would likely not be a medical device. The code does not change. The intended purpose does.</p>
+
+        <h3>What risk class?</h3>
+
+        <p><a href="https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32017R0745">Rule 11 of MDR Annex VIII</a> is the classification rule that most standalone decision-support software falls under. It is not the <em>only</em> rule that can apply to software, software that drives or influences another active device inherits that device&#8217;s rule, but for an app like Malik, Rule 11 is the relevant one. It has three sub-rules, each mapping to a different risk class.</p>
+
+        <p>Sub-rule 11a covers software that provides information used in diagnostic or therapeutic decisions. That is Malik. The physician uses cardiac parameters to assess heart health, which is diagnostic decision support. Class IIa.</p>
+
+        <p>Sub-rule 11b is where it gets uncomfortable. Software where a misrepresentation could lead to serious deterioration of health or trigger a surgical intervention falls into Class IIb. When I read that, I had to ask honestly whether a miscalculated HRV parameter in Malik could lead to serious deterioration. I do not have a clean answer. That is a judgment call that gets resolved in dialogue with a notified body, not something a developer can decide unilaterally.</p>
+
+        <p>The tension this creates is real. Adding more specific diagnostic claims, for example automated atrial fibrillation detection, increases clinical value but may push the classification to IIb or III. AF detection is the classic case: high clinical value, but it likely triggers a notified body audit of the algorithm itself. Each feature on your roadmap that adds a clinical claim should be evaluated for its classification impact before it is built, not after.</p>
+
+        <h3>What does Class IIa require in practice?</h3>
+
+        <ul>
+          <li>a quality management system (typically built against <a href="https://www.iso.org/standard/59752.html">ISO 13485</a>, which is the harmonized standard most manufacturers use to satisfy the MDR&#8217;s QMS requirement)</li>
+          <li>risk management per <a href="https://www.iso.org/standard/72704.html">ISO 14971</a></li>
+          <li>post-market surveillance of the medical device</li>
+          <li>technical files per MDR Annex II</li>
+          <li>audit by a <a href="https://health.ec.europa.eu/medical-devices-topics-interest/notified-bodies_en">notified body</a></li>
+          <li>clinical evaluation</li>
+        </ul>
+
+        <p>A notified body is an independent organization designated by an EU member state to assess whether your device and your processes meet MDR requirements. You cannot self-certify a Class IIa device.</p>
+
+        <p>The clinical evaluation requirement deserves more honesty than it usually gets in developer-facing writing. Under the old MDD, literature review and equivalence claims to existing products were a common shortcut. Under MDR, that shortcut has narrowed sharply. Article 61(5) requires contractual access to the equivalent device&#8217;s full technical documentation, which is essentially impossible to obtain from a competitor. For novel software, notified bodies increasingly expect your own clinical investigation or prospective clinical performance data. Small teams should plan for real clinical work, not assume they can lean on published literature alone.</p>
+
+        <p>The standard that would change my daily work most concretely is <a href="https://www.iso.org/standard/38421.html">IEC 62304</a>. It defines the software development lifecycle requirements: how you plan, document, verify and maintain your code. Every commit, every change, every test needs to fit into a traceable process. That is a different way of working than most developers are used to.</p>
+
+        <p>Kardi Ai went through exactly this process with their Polar H10-based system and achieved Class IIa certification. The path exists and it is navigable, though it is not short.</p>
+
+        <hr>
+
+        <h2>What does Firebase mean for health data?</h2>
+
+        <p>The ECG recordings, heart rate values, and cardiac parameters flowing through Malik fall under <a href="https://gdpr-info.eu/art-9-gdpr/">GDPR Article 9</a> as health data, the highest protection tier in European data protection law. Processing health data is prohibited by default unless you meet one of a narrow set of exceptions.</p>
+
+        <p>There are two that matter for a medical app, and which one applies depends on the setting. Article 9(2)(a), explicit, informed, specific, and freely given consent, is the one developers usually reach for first. For actual clinical use, though, Article 9(2)(h), processing necessary for medical diagnosis or the provision of health care by a professional under a confidentiality obligation, is often the more robust basis. Consent can be withdrawn at any time and is hard to characterize as &#8220;freely given&#8221; in a care relationship where the patient feels they have no real alternative. Several EU data protection authorities explicitly prefer 9(2)(h) for clinical contexts. Which basis fits depends on whether your app is used inside a care pathway or outside one, and it is worth deciding deliberately rather than defaulting to consent.</p>
+
+        <h3>Who is responsible for what?</h3>
+
+        <p>Firebase operates under a controller-processor model. I am the data controller. Google is the data processor for the core Firebase services covered by its Data Processing and Security Terms. Firebase services hold ISO 27001, SOC 1, SOC 2, and SOC 3 certifications. (Note that Google may act as a controller for limited service-improvement and telemetry purposes, which is worth reading in the current DPA.)</p>
+
+        <p>On paper, this is a workable foundation. In practice, there are pitfalls that are easy to miss.</p>
+
+        <h3>The pitfalls</h3>
+
+        <p>Data residency is not automatic. <strong>Firestore and Cloud Storage</strong> allow you to select EU regions but this is a configuration choice, not the default. If you did not explicitly set your Firestore location to an EEA region when creating the database, your patient ECG data may be stored on US servers. <strong>Firebase Authentication</strong> has historically stored identifier data on US infrastructure without a region selector; Google has been expanding data residency options, so verify the current state against Firebase&#8217;s documentation before you rely on it.</p>
+
+        <p>Firebase&#8217;s own operational telemetry may also flow through US infrastructure. Disabling unnecessary services like Analytics or Crashlytics reduces your exposure.</p>
+
+        <p>A <strong>Data Protection Impact Assessment (DPIA)</strong> is almost certainly required. GDPR Article 35 requires one when processing health data using new technologies at scale. A mobile app that records ECG data, transmits it to a cloud backend, and processes it for clinical purposes checks all three boxes. This is a legal obligation that should be completed before processing begins, not something to draft retroactively.</p>
+
+        <h3>Is Firebase the right choice for a medical device?</h3>
+
+        <p>For a prototype or research tool, which is where Malik currently sits, Firebase is workable. Configure Firestore for an EU region, disable non-essential analytics services, implement an appropriate legal basis for processing, activate Google&#8217;s Data Processing Agreement in your project settings, and document everything.</p>
+
+        <p>For a CE-marked medical device headed for market the answer gets more complicated. A notified body examining your technical file will ask where exactly the data is stored, who has access, what happens during a Google infrastructure update, how you guarantee data integrity, and what your recovery procedures are. With Firebase, many of those answers are &#8220;Google controls that, and I rely on their terms.&#8221; That is not a disqualifier, but it creates a dependency that is harder to document and defend than infrastructure you fully control.</p>
+
+        <p>EU-hosted alternatives like AWS Frankfurt, Azure Germany, or specialized medical cloud providers give you direct control over the processing environment and cleaner answers for auditors. Every architecture choice you make will need to be explained and defended in your technical file. Infrastructure is not just an engineering decision.</p>
+
+        <h3>What to check if you are already on Firebase</h3>
+
+        <p>Regardless of whether you are prototyping or heading for production, review these now:</p>
+
+        <p>Check if your Firestore data location is set to an EEA region. Verify the current data residency behavior of Firebase Authentication against Google&#8217;s documentation. Review which Firebase services are enabled and disable anything non-essential. Confirm that Google&#8217;s Data Processing Agreement is activated in your Firebase project settings. Draft a DPIA for health data. Decide which Article 9(2) basis you are relying on, and implement the corresponding consent or care-context workflow.</p>
+
+        <p>If you are building a prototype or research tool, this is sufficient to work responsibly with health data on Firebase.</p>
+
+        <p>If you are heading toward a CE-marked product, start planning your migration. Evaluate EU-hosted alternatives where you control the infrastructure directly. A notified body will expect clear answers about data residency, access control, integrity, and recovery, and those answers are easier to give when you own the environment.</p>
+
+        <hr>
+
+        <h2>Who sees the results - and why it matters</h2>
+
+        <p>In Malik&#8217;s current version, the physician sets up the Polar H10 with the patient, performs the measurement, and views the results on the same mobile device in the same session. When I designed it this way I was thinking about simplicity. It turns out that simplicity is also a regulatory advantage.</p>
+
+        <figure>
+          <img src="../images/screenshot-results-mock.png" alt="Malik results overview" width="300">
+          <figcaption>Measurement results as seen by the physician. The Health Score provides an at-a-glance assessment, while detailed HRV metrics (RMSSD, SDNN, pNN50) and cardiac morphology parameters (QRS duration, QT interval, cropped out) support clinical decision-making. This is the interface that MDR Annex I requires instructions for use to accompany.</figcaption>
+        </figure>
+
+        <p>There is one intended user: the physician. One interface. One device. The physician interprets the cardiac parameters directly and in the presence of the patient. There is no unsupervised patient interaction with clinical data, no remote transmission of results, and no automated alert that a patient receives alone at home.</p>
+
+        <p>This matters because the user interface is not just a screen, it is a regulatory deliverable. MDR Annex I requires instructions for use that clearly state the intended purpose, the intended user, indications, contraindications, and warnings. Even for a digital-only product with no physical packaging, these must exist and be accessible to the user. The physician needs to understand what the software does, what its limitations are, and when not to rely on its output.</p>
+
+        <h3>What changes when the product evolves?</h3>
+
+        <p>Most features on a typical medical software roadmap look straightforward from an engineering perspective and add significant complexity from a regulatory one.</p>
+
+        <p>A separate physician web dashboard means a second interface that needs its own usability evaluation. Under <a href="https://www.iso.org/standard/73007.html">IEC 62366-1</a>, each user interface must be assessed for use errors that could lead to harm. Two interfaces mean two assessments.</p>
+
+        <p>Home use by the patient changes the intended user from a trained physician to a layperson, and the usability requirements shift substantially. What does a patient do with a cardiac parameter they don&#8217;t understand? What if an alert causes unnecessary panic? What if they ignore a finding that needed medical attention? The instructions for use must be written for a non-expert, and the risk management file must account for foreseeable misuse by someone without medical training.</p>
+
+        <p>Automated alerts sent to the patient without a physician in the loop raise the hardest design question of all: who is overseeing the output? If the patient sees it first, human oversight stops being something satisfied by default and becomes a core design constraint you have to engineer for explicitly.</p>
+
+        <p>All of these features are buildable. Each one expands the regulatory surface area of the interface and increases the need for usability work, risk analysis and documentation. It is cheaper to know this during feature planning than to discover it afterward.</p>
+
+        <h3>A note on the EU AI Act</h3>
+
+        <p>You may have noticed I haven&#8217;t claimed Malik is outside the scope of the EU AI Act. The honest answer is that the boundary is genuinely unsettled. The Act defines an AI system around the capacity to <em>infer</em> outputs from inputs with some degree of autonomy, not strictly around whether a model was trained. Recital 12 and the Commission&#8217;s February 2025 guidelines on the AI system definition carve out systems based purely on rules defined by natural persons, which is where classical signal processing plausibly sits, but the line between &#8220;deterministic math&#8221; and &#8220;inference&#8221; is drawn by interpretation rather than by a clean technical test. For a cardiac app built on filters, beat detection and parameter calculation with no trained model, a reasoned argument that the AI Act does not apply is defensible, but it is a <em>position</em> that needs to be documented, not a conclusion I can hand down in a blog post. I will come back to this in a dedicated post once I have worked through it more carefully.</p>
+
+        <h3>Where Malik stands</h3>
+
+        <p>The current single-device, physician-supervised model keeps the interface layer as simple as it can be for a medical device. The physician is the intended user, they are trained, and they see results in context. This is a starting point that makes initial certification more approachable, with room to expand the interface as long as each step is taken with the compliance implications in mind.</p>
+
+        <hr>
+
+        <h2>The full picture</h2>
+
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>Architecture Layer</th>
+                <th>Regulatory Question</th>
+                <th>Key Frameworks</th>
+                <th>Status for Malik</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Polar H10 sensor</td>
+                <td>Consumer vs. medical device?</td>
+                <td>MDR qualification</td>
+                <td>Consumer device; certification attaches to the app+sensor system</td>
+              </tr>
+              <tr>
+                <td>Malik app + signal processing backend</td>
+                <td>Is the software a medical device? What class?</td>
+                <td>MDR Rule 11, MDCG 2019-11</td>
+                <td>Class IIa, diagnostic decision support for physician</td>
+              </tr>
+              <tr>
+                <td>Google Firebase</td>
+                <td>Health data compliance, data residency?</td>
+                <td>GDPR Art. 9, Data Processing Agreement</td>
+                <td>Needs EEA configuration, DPIA, Art. 9(2)(a) or 9(2)(h) basis</td>
+              </tr>
+              <tr>
+                <td>Signal processing pipeline</td>
+                <td>Does the EU AI Act apply?</td>
+                <td>EU AI Act Art. 3, Art. 6</td>
+                <td>Unsettled; defensible position needed, out of scope for this post</td>
+              </tr>
+              <tr>
+                <td>Physician interface</td>
+                <td>Usability, labeling, instructions for use?</td>
+                <td>MDR Annex I, IEC 62366-1</td>
+                <td>Single-user supervised setup, simplest regulatory case</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <p>One app. Five architecture layers. Each one raised a different regulatory question, governed by a different framework and requiring different documentation than the one before it.</p>
+
+        <p>The sensor does not protect you because the MDR classification attaches to the system you place on the market. The cloud infrastructure creates data protection obligations that go well beyond a standard privacy policy. And the user interface is a regulatory deliverable that shapes your risk classification by defining who the intended user is.</p>
+
+        <p>None of this is meant to discourage developers from building medical software. I find these frameworks genuinely interesting, and understanding them early is what separates a certifiable product from an expensive re-architecture later.</p>
+
+        <p>The path requires knowing where the boundaries are before you write the code, not after. If this walkthrough helps one developer ask the right questions earlier, it was worth writing.</p>
+
+        <aside class="post-author-note">
+          <p>I am a physicist turned data scientist, currently working in medical device software and finishing a PhD in biosignal data analysis. I plan to write more about the intersection of modern development practices and medical device regulation, including what happens when you add machine learning to a pipeline like this, and what &#8220;vibe coding&#8221; means for IEC 62304 traceability. If you are building something similar, I would like to hear about it.</p>
+        </aside>
+
+      </article>
+
+    </div>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer-inner">
+      <span>&copy; 2026 Oruç Kahriman</span>
+      <ul class="footer-links">
+        <li>
+          <a href="mailto:oruc.kahriman@charite.de" aria-label="Email">
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="4" width="20" height="16" rx="2"/><path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7"/></svg>
+            oruc.kahriman@charite.de
+          </a>
+        </li>
+        <li>
+          <a href="https://github.com/Oruc93" target="_blank" rel="noopener" aria-label="GitHub">
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0 1 12 6.844a9.59 9.59 0 0 1 2.504.337c1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.02 10.02 0 0 0 22 12.017C22 6.484 17.522 2 12 2z"/></svg>
+            GitHub
+          </a>
+        </li>
+        <li>
+          <a href="https://www.linkedin.com/in/oruc-kahriman-931b56122/" target="_blank" rel="noopener" aria-label="LinkedIn">
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor"><path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 0 1-2.063-2.065 2.064 2.064 0 1 1 2.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/></svg>
+            LinkedIn
+          </a>
+        </li>
+      </ul>
+    </div>
+  </footer>
+
+  <script src="../assets/js/main.js"></script>
+</body>
+</html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -4,5 +4,6 @@
   <url><loc>https://kahriman.org/cv.html</loc><changefreq>monthly</changefreq><priority>0.8</priority></url>
   <url><loc>https://kahriman.org/projects.html</loc><changefreq>monthly</changefreq><priority>0.8</priority></url>
   <url><loc>https://kahriman.org/blog/</loc><changefreq>weekly</changefreq><priority>0.7</priority></url>
+  <url><loc>https://kahriman.org/blog/malik-regulatory.html</loc><changefreq>monthly</changefreq><priority>0.8</priority></url>
   <url><loc>https://kahriman.org/bibliography.html</loc><changefreq>monthly</changefreq><priority>0.6</priority></url>
 </urlset>


### PR DESCRIPTION
## Summary

- Replaces "Posts coming soon" in `blog/index.html` with a proper post-card list (issue #7)
- Converts `post.md` to `blog/malik-regulatory.html` with full site shell, meta tags, `BlogPosting` JSON-LD schema, `og:image` set to `architecture.png`, and responsive table (issue #8)
- Adds `.post-author-note` aside style to `main.css` for the author bio separator
- Adds post to `sitemap.xml`

Closes #7
Closes #8

## Test plan

- [ ] `blog/index.html` shows post card with correct title, date (April 2026), tags, excerpt, and link to `malik-regulatory.html`
- [ ] `blog/malik-regulatory.html` renders without broken images (check `../images/` paths)
- [ ] Author bio is visually separated by a top border `<aside>`
- [ ] Summary table scrolls horizontally on mobile
- [ ] "Blog" nav link is active on the post page
- [ ] `og:image` resolves to `architecture.png` (check with a link preview tool)
- [ ] No text content differs from `post.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)